### PR TITLE
Add convention for naming instances of types

### DIFF
--- a/docs/fortranstyle.rst
+++ b/docs/fortranstyle.rst
@@ -116,6 +116,14 @@ modifications.
       end type TBroydenMixer
       :
       type(TBroydenMixer) :: broydenMixer
+
+
+* **Instances** referenced out of type-bound procedures are to be named `this`::
+
+      subroutine typeBoundProcedure(this, ...)
+        class(TType), intent(inout) :: this
+	:
+      end subroutine typeBoundProcedure
       
 
 * **Module** names follow **lower_case_with_underscore** convention::


### PR DESCRIPTION
Introduces a convention for naming the instances of types according to DFTB+ PR[526](https://github.com/dftbplus/dftbplus/pull/526) (closes #15).