### PR TITLE
Add section about Fortran block constructs

### DIFF
--- a/docs/fortranstyle.rst
+++ b/docs/fortranstyle.rst
@@ -339,7 +339,7 @@ Block constructs
 
     if (allocated(someArray)) someArray(:,:) = 0.0_dp
 
-    where (aa /= 0.0_dp) aa = 1.0_dp / aa
+    where (abs(aa) >= epsilon(0.0_dp)) aa = 1.0_dp / aa
 
     
 Allocation status

--- a/docs/fortranstyle.rst
+++ b/docs/fortranstyle.rst
@@ -305,6 +305,43 @@ Comments
       
       someStatementAfter
 
+
+Block constructs
+================
+
+* Block constructs are normally used in their verbose form, with block opening
+  and corresponding block closing in separate lines::
+
+    if (some_conditions) then
+      ! Do something
+      ...
+    end if
+
+* The closing form should have a space between the ``end`` keyword and the
+  construct type::
+
+    do ii = 1, 10
+      ...
+    end do  ! instead of "enddo"
+
+* If the block construct contains an expression within obligatory parentheses,
+  insert one space between the block type and the opening parenthesis::
+
+    if (some_condition) then  ! instead of "if(some_condition)"
+    
+    where (aa == 0)           ! instead of "where(aa == 0)"
+
+* Some block constructs have alternative one-line short forms without closing
+  statements (e.g. ``if``, ``where``). Only use their short form, if it is
+  readable and fits into a single line::
+
+    if (ioStat /= 0) return
+
+    if (allocated(someArray)) someArray(:,:) = 0.0_dp
+
+    where (aa /= 0.0_dp) aa = 1.0_dp / aa
+
+    
 Allocation status
 =================
 


### PR DESCRIPTION
I have tried to write up, how IMO short form of block constructs could be allowed. The guide lines should allow for less verbosity for the trivial cases, and forbid anything which would make the code less readable. I think, the two-line version is still OK, therefore, I've added it.

But, your mileage may vary, so it is open for discussions...
